### PR TITLE
update `AlignWith` to `EnforcedStyleAlignWith`

### DIFF
--- a/.rubucop.yml
+++ b/.rubucop.yml
@@ -14,7 +14,7 @@ Rails/OutputSafety:
 
 Lint/EndAlignment:
   Enabled: true
-  AlignWith: keyword
+  EnforcedStyleAlignWith: keyword
 
 Metrics/AbcSize:
   Enabled: false


### PR DESCRIPTION
I am proposing this because your vueport gem imports from here and is currently failing with the latest rubocop

```
Error: obsolete parameter AlignWith (for Lint/EndAlignment) found in /Users/markburns/code/vueport/.rubocop-https---raw-githubusercontent-com-samtgarson-my-config-master--rubucop-yml
`AlignWith` has been renamed to `EnforcedStyleAlignWith`
```